### PR TITLE
Allow frame offset starting at non-zero

### DIFF
--- a/quic_frame.go
+++ b/quic_frame.go
@@ -90,7 +90,7 @@ func ReassembleCRYPTOFrames(frames []QUICFrame) ([]byte, error) {
 	// Reassemble CRYPTO frames
 	var reassembled []byte = make([]byte, 0)
 	for _, frame := range cryptoFrames {
-		if uint64(len(reassembled)) == frame.(*CRYPTO).Offset {
+		if cryptoFrames[0].(*CRYPTO).Offset+uint64(len(reassembled)) == frame.(*CRYPTO).Offset {
 			reassembled = append(reassembled, frame.(*CRYPTO).data...)
 		} else {
 			return nil, fmt.Errorf("failed to reassemble CRYPTO frames")


### PR DESCRIPTION
The lowest offset of CRYPTO frames in a QUIC packet does not necessarily start at zero, such as the second packet of a connection using Kyber key in the client hello. 
related: refraction-networking/uquic#40